### PR TITLE
Changing from git-lfs to git-fat.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.lfs filter=lfs diff=lfs merge=lfs -text
+*.lfs filter=fat -crlf

--- a/.gitfat
+++ b/.gitfat
@@ -1,0 +1,2 @@
+[rsync]
+remote = amcg.ese.ic.ac.uk:~ggorman/opesci-data/Simple2D/


### PR DESCRIPTION
Reason for this change is that we ran into quota issues with
git-lfs due to travis checking out the binary files at each build.
